### PR TITLE
Tiedoston lahetys ja lataus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ out
 test-output
 atlassian-ide-plugin.xml
 .gradletasknamecache
+
+/files/

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.springframework.boot</groupId>
@@ -58,6 +58,18 @@
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.5</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-devtools</artifactId>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
+++ b/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
@@ -22,7 +22,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.headers().frameOptions().sameOrigin();
 
         http
-                .authorizeRequests().antMatchers("/register", "/files" ,"/files/{id}").permitAll().anyRequest().authenticated() // TODO Laita POST requestit /files endpointtiin autentikaation taakse
+                .authorizeRequests().antMatchers("/register", "/files" ,"/files/{id}", "/filetesting").permitAll().anyRequest().authenticated() // TODO Laita POST requestit /files endpointtiin autentikaation taakse
                 .and()
                 .formLogin().loginPage("/login").permitAll().failureUrl("/login-error")
                 .and()

--- a/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
+++ b/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
@@ -22,7 +22,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.headers().frameOptions().sameOrigin();
 
         http
-                .authorizeRequests().antMatchers("/register").permitAll().anyRequest().authenticated()
+                .authorizeRequests().antMatchers("/register", "/files").permitAll().anyRequest().authenticated() // TODO Laita POST requestit /files endpointtiin autentikaation taakse
                 .and()
                 .formLogin().loginPage("/login").permitAll().failureUrl("/login-error")
                 .and()

--- a/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
+++ b/src/main/java/com/group5/quacker/config/SecurityConfiguration.java
@@ -22,7 +22,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         http.headers().frameOptions().sameOrigin();
 
         http
-                .authorizeRequests().antMatchers("/register", "/files").permitAll().anyRequest().authenticated() // TODO Laita POST requestit /files endpointtiin autentikaation taakse
+                .authorizeRequests().antMatchers("/register", "/files" ,"/files/{id}").permitAll().anyRequest().authenticated() // TODO Laita POST requestit /files endpointtiin autentikaation taakse
                 .and()
                 .formLogin().loginPage("/login").permitAll().failureUrl("/login-error")
                 .and()

--- a/src/main/java/com/group5/quacker/config/WebConfiguration.java
+++ b/src/main/java/com/group5/quacker/config/WebConfiguration.java
@@ -15,6 +15,7 @@ public class WebConfiguration implements WebMvcConfigurer {
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
         registry.addViewController("/").setViewName("index");
+        registry.addViewController("/filetesting").setViewName("filetesting");
     }
 
     @Bean

--- a/src/main/java/com/group5/quacker/controllers/FileController.java
+++ b/src/main/java/com/group5/quacker/controllers/FileController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
@@ -25,8 +26,8 @@ public class FileController {
     @Autowired
     FileMapRepository fileMapRepository;
 
-    @GetMapping("/files")
-    public ResponseEntity getFile(@RequestParam("id") String id, @RequestParam(name = "with-original-name", required = false) String withOriginalName) throws IOException {
+    @GetMapping("/files/{id}")
+    public ResponseEntity getFile(@PathVariable("id") String id, @RequestParam(name = "with-original-name", required = false) String withOriginalName) throws IOException {
         FileMap fileMap = fileMapRepository.findByPublicId(id);
 
         if (fileMap == null) {
@@ -57,6 +58,6 @@ public class FileController {
         }
 
         // TODO Tää redirect on enimmäkseen testausta varten. Me kuitenkin halutaan et se redirect riippuu kontekstista.
-        return "redirect:/files?id=" + fileMap.getPublicId();
+        return "redirect:/files/" + fileMap.getPublicId();
     }
 }

--- a/src/main/java/com/group5/quacker/controllers/FileController.java
+++ b/src/main/java/com/group5/quacker/controllers/FileController.java
@@ -1,0 +1,62 @@
+package com.group5.quacker.controllers;
+
+import com.group5.quacker.entities.FileMap;
+import com.group5.quacker.repositories.FileMapRepository;
+import com.group5.quacker.services.FileService;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Controller
+public class FileController {
+    @Autowired
+    FileService fileService;
+
+    @Autowired
+    FileMapRepository fileMapRepository;
+
+    @GetMapping("/files")
+    public ResponseEntity getFile(@RequestParam("id") String id, @RequestParam(name = "with-original-name", required = false) String withOriginalName) throws IOException {
+        FileMap fileMap = fileMapRepository.findByPublicId(id);
+
+        if (fileMap == null) {
+            return new ResponseEntity(HttpStatus.NOT_FOUND);
+        }
+
+        InputStream inputStream = fileService.getInputStream(fileMap.getFileName());
+
+        if (inputStream == null) {
+            return new ResponseEntity(HttpStatus.NOT_FOUND);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", fileMap.getContentType());
+        if (withOriginalName != null) {
+            headers.add("Content-disposition", "attachment; filename=" + fileMap.getOriginalFileName());
+        }
+
+        return new ResponseEntity(IOUtils.toByteArray(inputStream), headers, HttpStatus.OK);
+    }
+
+    @PostMapping("/files")
+    public String postFile(@RequestParam("file") MultipartFile file, @RequestParam(value = "redirect", required = false) String redirect) throws IOException {
+        FileMap fileMap = fileService.storeFile(file);
+
+        if (redirect != null) {
+            return redirect;
+        }
+
+        // TODO Tää redirect on enimmäkseen testausta varten. Me kuitenkin halutaan et se redirect riippuu kontekstista.
+        return "redirect:/files?id=" + fileMap.getPublicId();
+    }
+}

--- a/src/main/java/com/group5/quacker/entities/FileMap.java
+++ b/src/main/java/com/group5/quacker/entities/FileMap.java
@@ -1,0 +1,60 @@
+package com.group5.quacker.entities;
+
+import javax.persistence.*;
+
+@Entity
+public class FileMap {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;
+
+    @Column(unique = true)
+    private String fileName;
+
+    @Column(unique = true)
+    private String publicId;
+
+    private String contentType;
+
+    private String originalFileName;
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public void setFileName(String fileName) {
+        this.fileName = fileName;
+    }
+
+    public String getPublicId() {
+        return publicId;
+    }
+
+    public void setPublicId(String publicId) {
+        this.publicId = publicId;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getOriginalFileName() {
+        return originalFileName;
+    }
+
+    public void setOriginalFileName(String originalFileName) {
+        this.originalFileName = originalFileName;
+    }
+}

--- a/src/main/java/com/group5/quacker/repositories/FileMapRepository.java
+++ b/src/main/java/com/group5/quacker/repositories/FileMapRepository.java
@@ -1,0 +1,8 @@
+package com.group5.quacker.repositories;
+
+import com.group5.quacker.entities.FileMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileMapRepository extends JpaRepository<FileMap, Long> {
+    FileMap findByPublicId(String uuid);
+}

--- a/src/main/java/com/group5/quacker/services/FileService.java
+++ b/src/main/java/com/group5/quacker/services/FileService.java
@@ -6,8 +6,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.servlet.http.HttpServletRequest;
 import java.io.*;
 import java.util.UUID;
 
@@ -15,9 +13,6 @@ import java.util.UUID;
 public class FileService {
     @Autowired
     FileMapRepository fileMapRepository;
-
-    @Autowired
-    private HttpServletRequest request;
 
     @Value("${fileStorage.path}")
     private String FILEPATH;

--- a/src/main/java/com/group5/quacker/services/FileService.java
+++ b/src/main/java/com/group5/quacker/services/FileService.java
@@ -1,0 +1,48 @@
+package com.group5.quacker.services;
+
+import com.group5.quacker.entities.FileMap;
+import com.group5.quacker.repositories.FileMapRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.*;
+import java.util.UUID;
+
+@Service
+public class FileService {
+    @Autowired
+    FileMapRepository fileMapRepository;
+
+    @Autowired
+    private HttpServletRequest request;
+
+    @Value("${fileStorage.path}")
+    private String FILEPATH;
+
+    public File getFile(String fileName) {
+        return new File(FILEPATH + "/" + fileName);
+    }
+
+    public InputStream getInputStream(String fileName) throws FileNotFoundException {
+        File file = getFile(fileName);
+        if (file == null) {
+            return null;
+        }
+        return new FileInputStream(file);
+    }
+
+    public FileMap storeFile(MultipartFile file) throws IOException {
+        FileMap fileMap = new FileMap();
+        fileMap.setFileName(UUID.randomUUID().toString());
+        fileMap.setPublicId(UUID.randomUUID().toString());
+        fileMap.setContentType(file.getContentType());
+        fileMap.setOriginalFileName(file.getOriginalFilename());
+        fileMapRepository.save(fileMap);
+
+        file.transferTo(new File(FILEPATH + "/" + fileMap.getFileName()));
+        return fileMap;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,6 @@
 jdbc:h2:mem:testdb
 #spring.datasource.url=jdbc:h2:file:~/database;DB_CLOSE_ON_EXIT=FALSE;AUTO_RECONNECT=TRUE
 
-
-
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
@@ -11,3 +9,5 @@ spring.jpa.hibernate.ddl-auto=update
 
 # Enabling H2 Console
 spring.h2.console.enabled=true
+
+fileStorage.path = ${QUACKER_FILE_STORAGE}

--- a/src/main/resources/templates/filetesting.html
+++ b/src/main/resources/templates/filetesting.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Quacker</title>
+</head>
+<body>
+<div>
+    <form method="POST" enctype="multipart/form-data" th:action="@{/files}">
+        <input type="file" name="file" />
+        <button type="submit">Upload</button>
+    </form>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Tiedostojen lähetys- ja latausrunko. Testattu kuvilla ja tekstitiedostoilla. Jos urliin laittaa query parametrin with-original-name niin selain lataa sen tiedoston sen alkuperäisellä nimellä. Tiedostojen sijaintia varten pitää laittaa ympäristömuuttuja tai serveri ei käynnisty (QUACKER_FILE_STORAGE).